### PR TITLE
Add Recogito web workspace for OIR JSON-LD data

### DIFF
--- a/oir/README.md
+++ b/oir/README.md
@@ -1,0 +1,28 @@
+# OIR Components
+
+This folder contains experimental tooling that supports working with the OIR material in this repository.
+
+## Recogito web component
+
+The [`recogito-web`](recogito-web/) directory bundles a small static web application that embeds the [Recogito](https://recogito.pelagios.org/) annotation environment for the JSON-LD texts that live in this repository. It allows the OIR material to be explored and annotated directly in a browser without needing to upload or download data manually.
+
+### Running locally
+
+1. Start a local HTTP server from the repository root so that the relative paths resolve correctly:
+   ```bash
+   python -m http.server 8000
+   ```
+2. Navigate to [http://localhost:8000/oir/recogito-web/](http://localhost:8000/oir/recogito-web/) in a modern browser.
+3. Pick one of the built-in JSON-LD datasets from the drop-down or load your own `.jsonld`/`.json` file through the file picker.
+4. Annotate the text with **Person**, **Place**, and **Event** tags using the Recogito interface. A summary panel keeps track of the tag counts as you work.
+5. Use the export button to download the annotations for further processing.
+
+The page loads RecogitoJS and its stylesheet from a CDN, so an internet connection is required for the annotation widget to function. The list of built-in datasets can be customised in [`recogito-web/app.js`](recogito-web/app.js).
+
+### Features
+
+- Parses the JSON-LD `@graph` structure and renders individual entries with their metadata.
+- Embeds RecogitoJS on every entry so that entities can be tagged directly in the browser.
+- Tracks Person/Place/Event tags across the whole dataset and displays live counts.
+- Provides simple text/year filtering as well as annotation export in JSON format.
+

--- a/oir/recogito-web/app.js
+++ b/oir/recogito-web/app.js
@@ -1,0 +1,563 @@
+(() => {
+  'use strict';
+
+  const datasetSelect = document.getElementById('dataset-select');
+  const fileInput = document.getElementById('file-input');
+  const searchInput = document.getElementById('search-input');
+  const entriesContainer = document.getElementById('entries');
+  const summaryContent = document.getElementById('summary-content');
+  const exportButton = document.getElementById('export-btn');
+  const resetButton = document.getElementById('reset-btn');
+  const datasetLabel = document.getElementById('dataset-label');
+
+  const BUILT_IN_DATASETS = [
+    {
+      id: 'annals-connacht',
+      label: 'Annals of Connacht (1224-1544)',
+      path: '../../annals_ireland/annals_connacht.jsonld'
+    }
+  ];
+
+  const MAX_ANNOTATION_LIST = 300;
+
+  let recogitoInstances = [];
+  let currentEntries = [];
+  let currentDatasetLabel = '';
+
+  init();
+
+  function init() {
+    populateDatasetSelector();
+    datasetSelect.addEventListener('change', (event) => {
+      const datasetId = event.target.value;
+      if (datasetId) {
+        loadBuiltInDataset(datasetId);
+      }
+    });
+
+    fileInput.addEventListener('change', handleFileUpload);
+    searchInput.addEventListener('input', filterEntries);
+    exportButton.addEventListener('click', exportAnnotations);
+    resetButton.addEventListener('click', resetAnnotations);
+
+    if (BUILT_IN_DATASETS.length) {
+      datasetSelect.value = BUILT_IN_DATASETS[0].id;
+      loadBuiltInDataset(BUILT_IN_DATASETS[0].id);
+    } else {
+      showEntriesMessage(
+        'No datasets have been configured yet. Use the file picker to load a JSON-LD file.',
+        false,
+        { clearLabel: true, resetState: true }
+      );
+    }
+  }
+
+  function populateDatasetSelector() {
+    datasetSelect.innerHTML = '';
+
+    BUILT_IN_DATASETS.forEach((dataset) => {
+      const option = document.createElement('option');
+      option.value = dataset.id;
+      option.textContent = dataset.label;
+      datasetSelect.appendChild(option);
+    });
+  }
+
+  async function loadBuiltInDataset(datasetId) {
+    const dataset = BUILT_IN_DATASETS.find((item) => item.id === datasetId);
+    if (!dataset) {
+      return;
+    }
+
+    currentDatasetLabel = dataset.label || '';
+    datasetLabel.textContent = dataset.label ? `${dataset.label} — loading…` : 'Loading dataset…';
+    showEntriesMessage('Loading dataset…', false, { resetState: true });
+    clearSummary();
+    disableExport();
+
+    try {
+      const response = await fetch(dataset.path);
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      const jsonld = await response.json();
+      handleLoadedData(jsonld, dataset.label);
+    } catch (error) {
+      console.error('Failed to load dataset:', error);
+      datasetLabel.textContent = dataset.label
+        ? `${dataset.label} — failed to load`
+        : 'Failed to load dataset';
+      showEntriesMessage(
+        'Unable to load the dataset. Ensure the development server is running from the repository root.',
+        true,
+        { resetState: true }
+      );
+    }
+  }
+
+  function handleFileUpload(event) {
+    const file = event.target.files && event.target.files[0];
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    currentDatasetLabel = file.name || '';
+    datasetLabel.textContent = file.name ? `${file.name} — loading…` : 'Reading local file…';
+    showEntriesMessage('Reading local file…', false, { resetState: true });
+    clearSummary();
+    disableExport();
+
+    reader.onload = () => {
+      try {
+        const jsonld = JSON.parse(reader.result);
+        handleLoadedData(jsonld, file.name);
+      } catch (error) {
+        console.error('Failed to parse local JSON-LD file:', error);
+        showEntriesMessage('The selected file is not valid JSON-LD.', true);
+      }
+    };
+
+    reader.onerror = () => {
+      console.error('Failed to read file:', reader.error);
+      showEntriesMessage('The selected file could not be read.', true);
+    };
+
+    reader.readAsText(file);
+  }
+
+  function handleLoadedData(jsonld, label) {
+    const entries = parseJsonLd(jsonld);
+    if (!entries.length) {
+      currentEntries = [];
+      currentDatasetLabel = label;
+      datasetLabel.textContent = label ? `${label} — 0 entries` : '';
+      showEntriesMessage('The selected dataset does not contain any textual entries.', true);
+      clearSummary();
+      return;
+    }
+
+    currentEntries = entries;
+    currentDatasetLabel = label || '';
+    datasetLabel.textContent = label ? `${label} — ${entries.length} entries` : `${entries.length} entries`;
+    searchInput.value = '';
+    renderEntries(entries);
+  }
+
+  function parseJsonLd(payload) {
+    const graph = Array.isArray(payload) ? payload : payload && payload['@graph'];
+    if (!Array.isArray(graph)) {
+      return [];
+    }
+
+    return graph
+      .map((node, index) => {
+        if (!node || typeof node !== 'object') {
+          return null;
+        }
+
+        const description = getFirst(node, ['dc:description', 'description', 'text', 'value']);
+        if (!description || typeof description !== 'string') {
+          return null;
+        }
+
+        return {
+          index,
+          id: node['@id'] || node.id || '',
+          date: getFirst(node, ['dc:date', 'date', 'when', 'time']),
+          source: getFirst(node, ['dc:source', 'source', 'collection']),
+          description: description.trim(),
+          raw: node
+        };
+      })
+      .filter((entry) => Boolean(entry));
+  }
+
+  function getFirst(node, keys) {
+    for (const key of keys) {
+      if (Object.prototype.hasOwnProperty.call(node, key) && node[key]) {
+        const value = node[key];
+        if (Array.isArray(value)) {
+          const first = value.find((item) => typeof item === 'string' && item.trim().length);
+          if (first) {
+            return first;
+          }
+          const nonString = value.find((item) => typeof item === 'number');
+          if (typeof nonString === 'number') {
+            return String(nonString);
+          }
+        } else if (typeof value === 'string') {
+          return value;
+        } else if (typeof value === 'number') {
+          return String(value);
+        }
+      }
+    }
+    return '';
+  }
+
+  function renderEntries(entries) {
+    destroyRecogitoInstances();
+    entriesContainer.innerHTML = '';
+
+    if (!ensureRecogitoAvailable()) {
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    entries.forEach((entry, position) => {
+      const article = document.createElement('article');
+      article.className = 'entry';
+      article.dataset.search = [entry.date, entry.source, entry.description].join(' ').toLowerCase();
+      article.dataset.entryId = entry.id || `entry-${position + 1}`;
+
+      const header = document.createElement('div');
+      header.className = 'entry-header';
+
+      const dateElement = document.createElement('span');
+      dateElement.className = 'entry-date';
+      dateElement.textContent = entry.date || 'Undated';
+
+      const sourceElement = document.createElement('span');
+      sourceElement.className = 'entry-source';
+      sourceElement.textContent = entry.source || currentDatasetLabel || 'Unknown source';
+
+      const numberElement = document.createElement('span');
+      numberElement.className = 'entry-number';
+      numberElement.textContent = `Entry ${position + 1}${entry.id ? ` • ${entry.id}` : ''}`;
+
+      header.append(dateElement, sourceElement, numberElement);
+
+      const textElement = document.createElement('div');
+      textElement.className = 'entry-text';
+      textElement.id = `entry-text-${position + 1}`;
+      textElement.textContent = entry.description;
+
+      article.append(header, textElement);
+      fragment.appendChild(article);
+
+      const instance = new Recogito({
+        content: textElement,
+        widgets: [
+          'COMMENT',
+          {
+            widget: 'TAG',
+            vocabulary: ['Person', 'Place', 'Event']
+          }
+        ]
+      });
+
+      instance.on('createAnnotation', refreshSummary);
+      instance.on('updateAnnotation', refreshSummary);
+      instance.on('deleteAnnotation', refreshSummary);
+
+      recogitoInstances.push({ instance, entry });
+    });
+
+    entriesContainer.appendChild(fragment);
+    refreshSummary();
+  }
+
+  function ensureRecogitoAvailable() {
+    if (typeof Recogito === 'undefined') {
+      showEntriesMessage(
+        'RecogitoJS could not be loaded. Please check your internet connection.',
+        true
+      );
+      clearSummary('RecogitoJS is required for annotation. Please check your internet connection and reload the page.');
+      disableExport();
+      return false;
+    }
+    return true;
+  }
+
+  function destroyRecogitoInstances() {
+    recogitoInstances.forEach(({ instance }) => {
+      if (instance && typeof instance.destroy === 'function') {
+        instance.destroy();
+      }
+    });
+    recogitoInstances = [];
+  }
+
+  function filterEntries() {
+    const query = (searchInput.value || '').trim().toLowerCase();
+    const entries = entriesContainer.querySelectorAll('.entry');
+    entries.forEach((element) => {
+      const haystack = element.dataset.search || '';
+      if (!query) {
+        element.classList.remove('hidden');
+      } else {
+        element.classList.toggle('hidden', !haystack.includes(query));
+      }
+    });
+  }
+
+  function refreshSummary() {
+    const annotations = collectAnnotations();
+
+    if (!annotations.length) {
+      clearSummary('No annotations yet. Tag people, places, and events to see live counts.');
+      disableExport();
+      return;
+    }
+
+    const totals = {
+      total: annotations.length,
+      person: 0,
+      place: 0,
+      event: 0,
+      untagged: 0,
+      other: {}
+    };
+
+    annotations.forEach(({ annotation }) => {
+      const tags = getAnnotationTags(annotation);
+      if (!tags.length) {
+        totals.untagged += 1;
+      }
+      tags.forEach((tag) => {
+        const key = tag.toLowerCase();
+        if (key === 'person') {
+          totals.person += 1;
+        } else if (key === 'place') {
+          totals.place += 1;
+        } else if (key === 'event') {
+          totals.event += 1;
+        } else {
+          totals.other[key] = (totals.other[key] || 0) + 1;
+        }
+      });
+    });
+
+    summaryContent.innerHTML = '';
+    summaryContent.appendChild(createCountCard('Total', totals.total, 'All annotations in view'));
+    summaryContent.appendChild(createCountCard('People', totals.person, 'Annotations tagged as Person'));
+    summaryContent.appendChild(createCountCard('Places', totals.place, 'Annotations tagged as Place'));
+    summaryContent.appendChild(createCountCard('Events', totals.event, 'Annotations tagged as Event'));
+
+    if (totals.untagged) {
+      summaryContent.appendChild(createCountCard('Untagged', totals.untagged, 'Annotations without tags'));
+    }
+
+    Object.entries(totals.other).forEach(([key, value]) => {
+      summaryContent.appendChild(
+        createCountCard(capitalize(key), value, 'Custom tag')
+      );
+    });
+
+    summaryContent.appendChild(createAnnotationDetails(annotations));
+    exportButton.disabled = false;
+  }
+
+  function clearSummary(message) {
+    summaryContent.innerHTML = '';
+    const placeholder = document.createElement('p');
+    placeholder.className = 'placeholder';
+    placeholder.textContent = message || 'No annotations yet.';
+    summaryContent.appendChild(placeholder);
+  }
+
+  function disableExport() {
+    exportButton.disabled = true;
+  }
+
+  function collectAnnotations() {
+    const aggregated = [];
+    recogitoInstances.forEach(({ instance, entry }) => {
+      if (!instance || typeof instance.getAnnotations !== 'function') {
+        return;
+      }
+      const annotations = instance.getAnnotations() || [];
+      annotations.forEach((annotation) => {
+        aggregated.push({ annotation, entry });
+      });
+    });
+    return aggregated;
+  }
+
+  function getAnnotationTags(annotation) {
+    const bodies = annotation && (annotation.body || annotation.bodies);
+    if (!Array.isArray(bodies)) {
+      return [];
+    }
+    return bodies
+      .filter((body) => body && body.purpose === 'tagging')
+      .map((body) => body.value || body.label || body.id || '')
+      .filter(Boolean);
+  }
+
+  function getAnnotationQuote(annotation) {
+    if (!annotation) {
+      return '';
+    }
+
+    if (annotation.quote) {
+      return annotation.quote;
+    }
+
+    const target = annotation.target || {};
+    const selector = target.selector;
+
+    if (Array.isArray(selector)) {
+      const quoteSelector = selector.find((item) => item && item.type === 'TextQuoteSelector');
+      if (quoteSelector && quoteSelector.exact) {
+        return quoteSelector.exact;
+      }
+    } else if (selector && selector.exact) {
+      return selector.exact;
+    }
+
+    return '';
+  }
+
+  function createCountCard(title, count, description) {
+    const card = document.createElement('div');
+    card.className = 'tag-count';
+
+    const valueElement = document.createElement('strong');
+    valueElement.textContent = count;
+
+    const titleElement = document.createElement('span');
+    titleElement.textContent = title;
+
+    const descriptionElement = document.createElement('small');
+    descriptionElement.textContent = description;
+
+    card.append(valueElement, titleElement, descriptionElement);
+    return card;
+  }
+
+  function createAnnotationDetails(annotations) {
+    const details = document.createElement('details');
+    details.className = 'annotation-details';
+    if (annotations.length <= 10) {
+      details.open = true;
+    }
+
+    const summary = document.createElement('summary');
+    summary.textContent = `Annotations (${annotations.length})`;
+    details.appendChild(summary);
+
+    const list = document.createElement('ul');
+    list.className = 'annotation-list';
+
+    const trimmed = annotations.slice(0, MAX_ANNOTATION_LIST);
+
+    trimmed.forEach(({ annotation, entry }) => {
+      const tags = getAnnotationTags(annotation);
+      const quote = truncateText(getAnnotationQuote(annotation) || '(no quote selected)', 220);
+      const listItem = document.createElement('li');
+
+      const tagElement = document.createElement('span');
+      tagElement.className = 'annotation-tag';
+      tagElement.textContent = tags.length ? tags.join(', ') : 'Untagged';
+
+      const quoteElement = document.createElement('span');
+      quoteElement.className = 'annotation-quote';
+      quoteElement.textContent = quote;
+
+      const metaElement = document.createElement('span');
+      metaElement.className = 'annotation-meta';
+      metaElement.textContent = `${entry.date || 'Undated'} • Entry ${entry.index + 1}`;
+
+      listItem.append(tagElement, quoteElement, metaElement);
+      list.appendChild(listItem);
+    });
+
+    if (annotations.length > trimmed.length) {
+      const remainder = document.createElement('li');
+      remainder.className = 'annotation-note';
+      remainder.textContent = `…and ${annotations.length - trimmed.length} more annotations.`;
+      list.appendChild(remainder);
+    }
+
+    details.appendChild(list);
+    return details;
+  }
+
+  function truncateText(text, maxLength) {
+    if (text.length <= maxLength) {
+      return text;
+    }
+    return `${text.slice(0, maxLength - 1)}…`;
+  }
+
+  function capitalize(text) {
+    if (!text) {
+      return '';
+    }
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+
+  function exportAnnotations() {
+    const annotations = collectAnnotations();
+    if (!annotations.length) {
+      return;
+    }
+
+    const exportPayload = annotations.map(({ annotation, entry }) => ({
+      entry: {
+        index: entry.index,
+        id: entry.id || null,
+        date: entry.date || null,
+        source: entry.source || null
+      },
+      annotation
+    }));
+
+    const blob = new Blob([JSON.stringify(exportPayload, null, 2)], {
+      type: 'application/json'
+    });
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const baseName = slugify(currentDatasetLabel || 'annotations');
+    const filename = `${baseName || 'annotations'}-${timestamp}.json`;
+
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function slugify(text) {
+    return text
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)+/g, '');
+  }
+
+  function resetAnnotations() {
+    if (!currentEntries.length) {
+      return;
+    }
+    renderEntries(currentEntries);
+    disableExport();
+  }
+
+  function showEntriesMessage(message, isError, options = {}) {
+    const { clearLabel = false, resetState = false } = options;
+
+    destroyRecogitoInstances();
+
+    if (resetState) {
+      currentEntries = [];
+    }
+
+    if (clearLabel) {
+      currentDatasetLabel = '';
+      datasetLabel.textContent = '';
+    }
+
+    entriesContainer.innerHTML = '';
+    const paragraph = document.createElement('p');
+    paragraph.className = `placeholder${isError ? ' error' : ''}`;
+    paragraph.textContent = message;
+    entriesContainer.appendChild(paragraph);
+  }
+})();

--- a/oir/recogito-web/index.html
+++ b/oir/recogito-web/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OIR Recogito Workspace</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@recogito/recogito-js@1.8.2/dist/recogito.min.css" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>OIR Recogito Workspace</h1>
+      <p>
+        Explore the JSON-LD texts in this repository and tag <strong>people</strong>,
+        <strong>places</strong>, and <strong>events</strong> without leaving your
+        browser. Choose one of the built-in datasets or load your own file and
+        start annotating with Recogito.
+      </p>
+    </header>
+
+    <main>
+      <section id="controls" aria-label="Dataset controls">
+        <div class="control-row">
+          <label class="control">
+            <span>Built-in dataset</span>
+            <select id="dataset-select" aria-label="Select a built-in dataset"></select>
+          </label>
+          <label class="control">
+            <span>Load local JSON-LD</span>
+            <input
+              type="file"
+              id="file-input"
+              accept=".json,.jsonld,.ldjson,application/ld+json"
+              aria-label="Upload a local JSON-LD file"
+            />
+          </label>
+          <label class="control">
+            <span>Filter entries</span>
+            <input
+              type="search"
+              id="search-input"
+              placeholder="Type to filter by year or text"
+              aria-label="Filter entries"
+            />
+          </label>
+        </div>
+        <div class="control-row">
+          <button id="reset-btn" type="button">Clear annotations</button>
+          <button id="export-btn" type="button" disabled>Export annotations</button>
+        </div>
+        <p class="hint">
+          Tip: annotations are stored in your browser memory. Use the export button
+          to save them as JSON for further processing.
+        </p>
+      </section>
+
+      <section id="summary" aria-label="Annotation summary">
+        <h2>Annotation summary</h2>
+        <p id="dataset-label" class="dataset-label"></p>
+        <div id="summary-content" class="summary-content">
+          <p class="placeholder">No annotations yet.</p>
+        </div>
+      </section>
+
+      <section id="entries" aria-live="polite" aria-label="Dataset entries"></section>
+    </main>
+
+    <footer>
+      <p>
+        Powered by <a href="https://recogito.pelagios.org/" target="_blank" rel="noopener">Recogito</a>
+        and <a href="https://github.com/pelagios/recogito-js" target="_blank" rel="noopener">RecogitoJS</a>.
+      </p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/@recogito/recogito-js@1.8.2/dist/recogito.min.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/oir/recogito-web/styles.css
+++ b/oir/recogito-web/styles.css
@@ -1,0 +1,307 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  --bg: #f7f7f7;
+  --panel-bg: #ffffff;
+  --accent: #2663d0;
+  --border: #d9d9d9;
+  --text: #2d2d2d;
+  --muted: #666666;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+header {
+  background: var(--accent);
+  color: #ffffff;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+}
+
+header h1 {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+}
+
+header p {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+section {
+  background: var(--panel-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 10px 24px rgba(12, 41, 91, 0.05);
+}
+
+#controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.control {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.control span {
+  font-size: 0.875rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+select,
+input[type="search"],
+input[type="file"] {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 1rem;
+  background: #fff;
+  color: var(--text);
+}
+
+input[type="file"] {
+  padding: 0.45rem 0.5rem;
+}
+
+button {
+  align-self: flex-start;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button[disabled] {
+  background: #b7b7b7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button:not([disabled]):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(38, 99, 208, 0.25);
+}
+
+button#reset-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  box-shadow: none;
+}
+
+button#reset-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+#summary h2 {
+  margin-top: 0;
+  font-size: 1.35rem;
+}
+
+.dataset-label {
+  margin: 0.25rem 0 1rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.summary-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.summary-content details {
+  grid-column: 1 / -1;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  background: rgba(38, 99, 208, 0.05);
+}
+
+.summary-content details summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.annotation-list {
+  margin: 0.75rem 0 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.annotation-list li {
+  list-style: disc;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.annotation-tag {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.annotation-quote {
+  font-style: italic;
+  color: var(--text);
+}
+
+.annotation-meta {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.annotation-note {
+  list-style: none;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.placeholder {
+  margin: 0;
+  color: var(--muted);
+}
+
+.placeholder.error {
+  color: #b42318;
+}
+
+.tag-count {
+  border-radius: 10px;
+  background: rgba(38, 99, 208, 0.1);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.tag-count strong {
+  font-size: 1.2rem;
+}
+
+.tag-count small {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+#entries {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.entry {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: #fff;
+}
+
+.entry-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: baseline;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.5rem;
+}
+
+.entry-date {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.entry-source {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.entry-number {
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.entry-text {
+  font-size: 1rem;
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+.entry.hidden {
+  display: none;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+footer a {
+  color: var(--accent);
+}
+
+@media (max-width: 720px) {
+  header {
+    padding: 2rem 1rem;
+  }
+
+  main {
+    padding: 1.5rem 1rem 3rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an `oir` component that ships a browser-based Recogito workspace for the JSON-LD texts
- build a static UI around RecogitoJS with dataset selection, search, annotation summaries, and export tooling
- document setup and usage in `oir/README.md`

## Testing
- not run (static web component)


------
https://chatgpt.com/codex/tasks/task_e_68c9c51d3a70832d8e3f7f550ddf8035